### PR TITLE
User registration

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -14,7 +14,7 @@ gem "puma", "~> 3.11"
 # Use Redis adapter to run Action Cable in production
 # gem 'redis', '~> 4.0'
 # Use ActiveModel has_secure_password
-# gem 'bcrypt', '~> 3.1.7'
+gem "bcrypt", "~> 3.1.7"
 
 # Use ActiveStorage variant
 # gem 'mini_magick', '~> 4.8'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -46,6 +46,7 @@ GEM
       public_suffix (>= 2.0.2, < 5.0)
     arel (9.0.0)
     ast (2.4.2)
+    bcrypt (3.1.18)
     bootsnap (1.12.0)
       msgpack (~> 1.2)
     builder (3.2.4)
@@ -212,6 +213,7 @@ PLATFORMS
   x86_64-darwin-21
 
 DEPENDENCIES
+  bcrypt (~> 3.1.7)
   bootsnap (>= 1.1.0)
   byebug
   factory_bot_rails

--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -1,0 +1,11 @@
+class Api::V1::UsersController < ApplicationController
+  def create
+    user_params = JSON.parse(params["_json"], symbolize_names: true)
+    user = User.new(user_params)
+    if user.save
+      render json: UsersSerializer.new(user), status: :created
+    else
+      render json: {error: user.errors.full_messages.to_sentence}, status: 400
+    end
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,6 +1,16 @@
 class User < ApplicationRecord
   has_secure_password
+  before_create :set_api_key
 
   validates_presence_of :email
   validates :email, uniqueness: true
+  validates :api_key, uniqueness: true
+
+  private
+
+  def set_api_key
+    if api_key.nil?
+      self.api_key = SecureRandom.hex(10)
+    end
+  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,0 +1,6 @@
+class User < ApplicationRecord
+  has_secure_password
+
+  validates_presence_of :email
+  validates :email, uniqueness: true
+end

--- a/app/serializers/users_serializer.rb
+++ b/app/serializers/users_serializer.rb
@@ -1,0 +1,4 @@
+class UsersSerializer
+  include JSONAPI::Serializer
+  attributes :email, :api_key
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,6 +3,7 @@ Rails.application.routes.draw do
     namespace :v1 do
       resources :forecast, only: [:index]
       resources :backgrounds, only: [:index]
+      resources :users, only: [:create]
     end
   end
 end

--- a/db/migrate/20220612230106_create_users.rb
+++ b/db/migrate/20220612230106_create_users.rb
@@ -1,0 +1,10 @@
+class CreateUsers < ActiveRecord::Migration[5.2]
+  def change
+    create_table :users do |t|
+      t.string :email
+      t.string :password_digest
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20220612232349_add_api_key_to_users.rb
+++ b/db/migrate/20220612232349_add_api_key_to_users.rb
@@ -1,0 +1,5 @@
+class AddApiKeyToUsers < ActiveRecord::Migration[5.2]
+  def change
+    add_column :users, :api_key, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,9 +10,16 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 0) do
+ActiveRecord::Schema.define(version: 2022_06_12_230106) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "users", force: :cascade do |t|
+    t.string "email"
+    t.string "password_digest"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
 
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_06_12_230106) do
+ActiveRecord::Schema.define(version: 2022_06_12_232349) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -20,6 +20,7 @@ ActiveRecord::Schema.define(version: 2022_06_12_230106) do
     t.string "password_digest"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "api_key"
   end
 
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,0 +1,26 @@
+require "rails_helper"
+
+describe User, type: :model do
+  describe "validations" do
+    it { should validate_presence_of :name }
+    it { should validate_presence_of :email }
+
+    describe "email" do
+      before do
+        @user_1 = User.create!(email: "wokeupthismorning@gmail.com", password: "test123", password_confirmation: "test123")
+      end
+
+      it { should allow_value("cleavermovie@gmail.com").for(:email) }
+      it { should_not allow_value("wokeupthismorning@gmail.com").for(:email) }
+    end
+
+    it { should validate_presence_of(:password) }
+    it { should have_secure_password }
+
+    it "should not have a password attribute and the password_digest attribute should be a hash" do
+      user = User.create(email: "test@test.com", password: "password123", password_confirmation: "password123")
+      expect(user).to_not have_attribute(:password)
+      expect(user.password_digest).to_not eq("password123")
+    end
+  end
+end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -18,6 +18,7 @@ describe User, type: :model do
 
     it "should not have a password attribute and the password_digest attribute should be a hash" do
       user = User.create(email: "test@test.com", password: "password123", password_confirmation: "password123")
+      binding.pry
       expect(user).to_not have_attribute(:password)
       expect(user.password_digest).to_not eq("password123")
     end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -18,9 +18,16 @@ describe User, type: :model do
 
     it "should not have a password attribute and the password_digest attribute should be a hash" do
       user = User.create(email: "test@test.com", password: "password123", password_confirmation: "password123")
-      binding.pry
+
       expect(user).to_not have_attribute(:password)
       expect(user.password_digest).to_not eq("password123")
+    end
+
+    it "should have a unique api_key generated upon creation" do
+      user_1 = User.create!(email: "test1@test.com", password: "password123", password_confirmation: "password123")
+      user_2 = User.create!(email: "test2@test.com", password: "password123", password_confirmation: "password123")
+
+      expect(user_1.api_key).not_to eq(user_2.api_key)
     end
   end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -2,7 +2,6 @@ require "rails_helper"
 
 describe User, type: :model do
   describe "validations" do
-    it { should validate_presence_of :name }
     it { should validate_presence_of :email }
 
     describe "email" do

--- a/spec/requests/api/v1/backgrounds_request_spec.rb
+++ b/spec/requests/api/v1/backgrounds_request_spec.rb
@@ -6,6 +6,8 @@ describe "backgrounds request" do
       headers = {"CONTENT_TYPE" => "application/json"}
       get "/api/v1/backgrounds", headers: headers, params: {location: "denver,co"}
 
+      expect(response).to have_http_status(200)
+
       response_body = JSON.parse(response.body, symbolize_names: true)
       background = response_body[:data]
 

--- a/spec/requests/api/v1/forecast_request_spec.rb
+++ b/spec/requests/api/v1/forecast_request_spec.rb
@@ -6,6 +6,8 @@ describe "forecast request" do
       headers = {"CONTENT_TYPE" => "application/json"}
       get "/api/v1/forecast", headers: headers, params: {location: "denver,co"}
 
+      expect(response).to have_http_status(200)
+
       response_body = JSON.parse(response.body, symbolize_names: true)
       forecast = response_body[:data]
 

--- a/spec/requests/api/v1/users_request_spec.rb
+++ b/spec/requests/api/v1/users_request_spec.rb
@@ -42,7 +42,6 @@ describe "users request" do
       expect(response).to have_http_status(400)
 
       response_body = JSON.parse(response.body, symbolize_names: true)
-      binding.pry
 
       expect(response_body).to have_key(:error)
       expect(response_body[:error]).to be_a String

--- a/spec/requests/api/v1/users_request_spec.rb
+++ b/spec/requests/api/v1/users_request_spec.rb
@@ -8,10 +8,9 @@ describe "users request" do
         password: "test123",
         password_confirmation: "test123"
       }
+      headers = {"CONTENT_TYPE" => "application/json"}
 
-      headers = {"CONTENT_TYPE" => "application/json", "ACCEPT" => "application/json"}
-
-      post "/api/v1/users", json_payload.to_json, headers: headers
+      post "/api/v1/users", headers: headers, params: json_payload.to_json, as: :json
 
       expect(response).to have_http_status(201)
 
@@ -36,10 +35,9 @@ describe "users request" do
         password: "test123",
         password_confirmation: "test123"
       }
+      headers = {"CONTENT_TYPE" => "application/json"}
 
-      headers = {"CONTENT_TYPE" => "application/json", "ACCEPT" => "application/json"}
-
-      post "/api/v1/users", json_payload.to_json, headers: headers
+      post "/api/v1/users", headers: headers, params: json_payload.to_json, as: :json
 
       expect(response).to have_http_status(201)
 

--- a/spec/requests/api/v1/users_request_spec.rb
+++ b/spec/requests/api/v1/users_request_spec.rb
@@ -28,7 +28,7 @@ describe "users request" do
     end
 
     it "sends back a 400 error for bad user params" do
-      user = User.new(email: "test@testing.com", password: "test123", password_confirmation: "test123")
+      user = User.create!(email: "test@testing.com", password: "test123", password_confirmation: "test123")
 
       json_payload = {
         email: "test@testing.com",
@@ -39,9 +39,10 @@ describe "users request" do
 
       post "/api/v1/users", headers: headers, params: json_payload.to_json, as: :json
 
-      expect(response).to have_http_status(201)
+      expect(response).to have_http_status(400)
 
       response_body = JSON.parse(response.body, symbolize_names: true)
+      binding.pry
 
       expect(response_body).to have_key(:error)
       expect(response_body[:error]).to be_a String

--- a/spec/requests/api/v1/users_request_spec.rb
+++ b/spec/requests/api/v1/users_request_spec.rb
@@ -1,0 +1,52 @@
+require "rails_helper"
+
+describe "users request" do
+  describe "POST new user" do
+    it "creates a new user in the database using the body of the request and generates an API key" do
+      json_payload = {
+        email: "test@testing.com",
+        password: "test123",
+        password_confirmation: "test123"
+      }
+
+      headers = {"CONTENT_TYPE" => "application/json", "ACCEPT" => "application/json"}
+
+      post "/api/v1/users", json_payload.to_json, headers: headers
+
+      expect(response).to have_http_status(201)
+
+      response_body = JSON.parse(response.body, symbolize_names: true)
+      new_user = response_body[:data]
+
+      expect(new_user[:type]).to eq("users")
+      expect(new_user).to have_key(:id)
+      expect(new_user[:id]).to be_a String
+      expect(new_user).to have_key(:attributes)
+      expect(new_user[:attributes]).to be_a Hash
+      expect(new_user[:attributes][:email]).to eq(json_payload[:email])
+      expect(new_user[:attributes]).to have_key(:api_key)
+      expect(new_user[:attributes][:api_key]).to be_a String
+    end
+
+    it "sends back a 400 error for bad user params" do
+      user = User.new(email: "test@testing.com", password: "test123", password_confirmation: "test123")
+
+      json_payload = {
+        email: "test@testing.com",
+        password: "test123",
+        password_confirmation: "test123"
+      }
+
+      headers = {"CONTENT_TYPE" => "application/json", "ACCEPT" => "application/json"}
+
+      post "/api/v1/users", json_payload.to_json, headers: headers
+
+      expect(response).to have_http_status(201)
+
+      response_body = JSON.parse(response.body, symbolize_names: true)
+
+      expect(response_body).to have_key(:error)
+      expect(response_body[:error]).to be_a String
+    end
+  end
+end


### PR DESCRIPTION
This branch accomplishes the following: 

-creates a `User` model, which has an `email` attribute and a `password_digest` attribute, which is an encrypted hash translation of the user's `password`
-adds an `api_key` attribute to `Users`, which is generated by `SecureRandom.hex(10)` in a `before_create` action called `set_api_key`, which generates a unique `api_key` for any new user before saving it to the database 
-adds a `POST /api/v1/users` endpoint, which takes a raw json payload containing user data to create a new user to the database
-creates a `UsersSerializer`, which sends renders the new user data when the user is successfully created and renders a 400 error with the `.save` errors if the user is not successfully created